### PR TITLE
MD5: Do not strip new line

### DIFF
--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -377,7 +377,6 @@ exports.calculateMD5 = (string) =>
 
   function utf8Encode(str)
   {
-    str = str.replace(/\r\n/g, '\n');
     let utftext = '';
 
     for (let n = 0; n < str.length; n++)


### PR DESCRIPTION
Closes #609.

Verified with MacOS MD5 command. New line is not removed from the string.